### PR TITLE
Experimental tweaks to enable basic profiling on RISC-V cores

### DIFF
--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -2335,6 +2335,10 @@ void IterationLogic::moveResultTo(std::vector<Result>& results) noexcept {
 
 #    if ANKERL_NANOBENCH(PERF_COUNTERS)
 
+#ifdef __riscv
+#define RISCV_BM_PERF
+#endif
+
 #ifdef RISCV_BM_PERF
 
 static inline unsigned long riscv64_arch_cycle(void)
@@ -2388,12 +2392,6 @@ public:
         }
 
 #ifdef RISCV_BM_PERF
-        auto const numBytes = sizeof(uint64_t) * mCounters.size();
-
-        Clock::time_point start;
-        Clock::time_point end = Clock::now();
-        uint64_t time_val = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
-
         mCounters[0] = 2; // count
         mCounters[1] = 0;
         mCounters[2] = 0;
@@ -2420,12 +2418,6 @@ public:
         }
 
 #ifdef RISCV_BM_PERF
-        auto const numBytes = sizeof(uint64_t) * mCounters.size();
-
-        Clock::time_point start;
-        Clock::time_point end = Clock::now();
-        uint64_t time_val = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
-
         mCounters[0] = 2; // count
         mCounters[1] = 0;
         mCounters[2] = 0;
@@ -2615,7 +2607,9 @@ bool LinuxPerformanceCounters::monitor(uint32_t type, uint64_t eventid, Target t
 
 #ifdef RISCV_BM_PERF
     uint64_t id = 0;
-    
+    if (type != PERF_TYPE_HARDWARE) {
+        return false;
+    }
     switch (eventid) {
         case PERF_COUNT_HW_INSTRUCTIONS:    id = 0; break;
         case PERF_COUNT_HW_REF_CPU_CYCLES:  id = 1; break;

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -2335,6 +2335,23 @@ void IterationLogic::moveResultTo(std::vector<Result>& results) noexcept {
 
 #    if ANKERL_NANOBENCH(PERF_COUNTERS)
 
+#ifdef RISCV_BM_PERF
+
+static inline unsigned long riscv64_arch_cycle(void)
+{
+    unsigned long res;
+    asm ("csrr %0, cycle" : "=r"(res) :: "memory");
+    return res;
+}
+
+static inline unsigned long riscv64_arch_instret(void)
+{
+    unsigned long res;
+    asm ("csrr %0, instret" : "=r"(res) :: "memory");
+    return res;
+}
+#endif
+
 ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
 class LinuxPerformanceCounters {
 public:
@@ -2370,6 +2387,22 @@ public:
             return;
         }
 
+#ifdef RISCV_BM_PERF
+        auto const numBytes = sizeof(uint64_t) * mCounters.size();
+
+        Clock::time_point start;
+        Clock::time_point end = Clock::now();
+        uint64_t time_val = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+
+        mCounters[0] = 2; // count
+        mCounters[1] = 0;
+        mCounters[2] = 0;
+        mCounters[3] = riscv64_arch_instret(); 
+        mCounters[4] = 0;                // instr id
+        mCounters[5] = riscv64_arch_cycle();
+        mCounters[6] = 1;                // cycle id
+        mHasError = false;
+#else
         // NOLINTNEXTLINE(hicpp-signed-bitwise)
         mHasError = -1 == ioctl(mFd, PERF_EVENT_IOC_RESET, PERF_IOC_FLAG_GROUP);
         if (mHasError) {
@@ -2378,6 +2411,7 @@ public:
 
         // NOLINTNEXTLINE(hicpp-signed-bitwise)
         mHasError = -1 == ioctl(mFd, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP);
+#endif        
     }
 
     inline void endMeasure() {
@@ -2385,6 +2419,22 @@ public:
             return;
         }
 
+#ifdef RISCV_BM_PERF
+        auto const numBytes = sizeof(uint64_t) * mCounters.size();
+
+        Clock::time_point start;
+        Clock::time_point end = Clock::now();
+        uint64_t time_val = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+
+        mCounters[0] = 2; // count
+        mCounters[1] = 0;
+        mCounters[2] = 0;
+        mCounters[3] = riscv64_arch_instret() - mCounters[3]; 
+        mCounters[4] = 0; // id
+        mCounters[5] = riscv64_arch_cycle() - mCounters[5];
+        mCounters[6] = 1; // id
+        mHasError = false;
+#else
         // NOLINTNEXTLINE(hicpp-signed-bitwise)
         mHasError = (-1 == ioctl(mFd, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP));
         if (mHasError) {
@@ -2394,6 +2444,7 @@ public:
         auto const numBytes = sizeof(uint64_t) * mCounters.size();
         auto ret = read(mFd, mCounters.data(), numBytes);
         mHasError = ret != static_cast<ssize_t>(numBytes);
+#endif
     }
 
     void updateResults(uint64_t numIters);
@@ -2562,6 +2613,16 @@ bool LinuxPerformanceCounters::monitor(uint32_t type, uint64_t eventid, Target t
         return false;
     }
 
+#ifdef RISCV_BM_PERF
+    uint64_t id = 0;
+    
+    switch (eventid) {
+        case PERF_COUNT_HW_INSTRUCTIONS:    id = 0; break;
+        case PERF_COUNT_HW_REF_CPU_CYCLES:  id = 1; break;
+        default: return false;
+    }
+   
+#else
     auto pea = perf_event_attr();
     std::memset(&pea, 0, sizeof(perf_event_attr));
     pea.type = type;
@@ -2596,6 +2657,7 @@ bool LinuxPerformanceCounters::monitor(uint32_t type, uint64_t eventid, Target t
         // couldn't get id
         return false;
     }
+#endif
 
     // insert into map, rely on the fact that map's references are constant.
     mIdToTarget.emplace(id, target);
@@ -2614,6 +2676,15 @@ PerformanceCounters::PerformanceCounters()
     , mVal()
     , mHas() {
 
+#ifdef RISCV_BM_PERF
+    mHas.cpuCycles = mPc->monitor(PERF_COUNT_HW_REF_CPU_CYCLES, LinuxPerformanceCounters::Target(&mVal.cpuCycles, true, false));
+    mHas.instructions = mPc->monitor(PERF_COUNT_HW_INSTRUCTIONS, LinuxPerformanceCounters::Target(&mVal.instructions, true, true));
+
+    mHas.pageFaults = false;
+    mHas.contextSwitches = false;
+    mHas.branchInstructions = false;
+    mHas.branchMisses = false;
+#else
     mHas.pageFaults = mPc->monitor(PERF_COUNT_SW_PAGE_FAULTS, LinuxPerformanceCounters::Target(&mVal.pageFaults, true, false));
     mHas.cpuCycles = mPc->monitor(PERF_COUNT_HW_REF_CPU_CYCLES, LinuxPerformanceCounters::Target(&mVal.cpuCycles, true, false));
     mHas.contextSwitches =
@@ -2623,6 +2694,7 @@ PerformanceCounters::PerformanceCounters()
         mPc->monitor(PERF_COUNT_HW_BRANCH_INSTRUCTIONS, LinuxPerformanceCounters::Target(&mVal.branchInstructions, true, false));
     mHas.branchMisses = mPc->monitor(PERF_COUNT_HW_BRANCH_MISSES, LinuxPerformanceCounters::Target(&mVal.branchMisses, true, false));
     // mHas.branchMisses = false;
+#endif
 
     mPc->start();
     mPc->calibrate([] {

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -3287,10 +3287,10 @@ std::vector<BigO> Bench::complexityBigO() const {
         return n;
     });
     bigOs.emplace_back("O(log n)", rangeMeasure, [](double n) {
-        return std::log2(n);
+        return log2(n);
     });
     bigOs.emplace_back("O(n log n)", rangeMeasure, [](double n) {
-        return n * std::log2(n);
+        return n * log2(n);
     });
     bigOs.emplace_back("O(n^2)", rangeMeasure, [](double n) {
         return n * n;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -25,13 +25,20 @@ target_sources_local(nb PRIVATE
     tutorial_fluctuating_v2.cpp
     tutorial_mustache.cpp
     tutorial_render_simple.cpp    
-    tutorial_slow_v1.cpp
-    tutorial_slow_v2.cpp
     unit_api.cpp
     unit_cold.cpp
     unit_exact_iters_and_epochs.cpp
     unit_romutrio.cpp
-    unit_templates.cpp
-    unit_timeunit.cpp
     unit_to_s.cpp
 )
+
+find_package(Threads)
+
+if (Threads_FOUND)
+target_sources_local(nb PRIVATE
+    tutorial_slow_v1.cpp
+    tutorial_slow_v2.cpp
+    unit_timeunit.cpp
+    unit_templates.cpp
+)
+endif()

--- a/src/test/app/doctest.cpp
+++ b/src/test/app/doctest.cpp
@@ -1,2 +1,14 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+// FIXME: DOCTEST doesn't support baremetal targets without mutex & pthreads
+#ifndef __linux
+#define DOCTEST_CONFIG_NO_POSIX_SIGNALS
+namespace std {
+    struct mutex {
+        void lock() {}
+        void unlock() {}
+    };
+}
+#endif
+
 #include <thirdparty/doctest/doctest.h>

--- a/src/test/tutorial_complexity_sort.cpp
+++ b/src/test/tutorial_complexity_sort.cpp
@@ -34,7 +34,7 @@ TEST_CASE("tutorial_complexity_sort") {
 
     // calculates bigO for a custom function
     auto logLogN = bench.complexityBigO("O(log log n)", [](double n) {
-        return std::log2(std::log2(n));
+        return log2(log2(n));
     });
     std::cout << logLogN << std::endl;
 }


### PR DESCRIPTION
*PR is intended only for discussion*

Linux adds instr/cycle/IPC targets for RISC-V. Numbers are approximate - code is not handling U/M and Linux kernel activities.
Baremetal is missing std::mutex and other features for doctest, and can't be fully tested yet.